### PR TITLE
Add Redocly lint workflow and README instructions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  redocly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npx @redocly/cli@latest lint openapi.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# OptiOffice Contracts
+
+This repository contains the OpenAPI contract for the OptiOffice API.
+
+## Linting
+
+We use [Redocly CLI](https://redocly.com/docs/cli/) to lint the OpenAPI specification.
+
+### Run locally
+
+```sh
+npx @redocly/cli lint openapi.yaml
+```
+
+### Run in CI
+
+The GitHub Actions workflow `.github/workflows/lint.yml` runs the lint check on every push and pull request.


### PR DESCRIPTION
Resolves #1
## Summary
- add GitHub workflow to lint OpenAPI spec using Redocly CLI
- document lint usage in README

## Testing
- `npx @redocly/cli lint openapi.yaml` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@redocly%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68c02549fd9883279a8e0e7f485a5964