### PR TITLE
feat: add organization endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OptiOffice API
-  version: 0.2.0
+  version: 0.3.0
 servers:
   - url: https://api.optioffice.local/v1
 components:
@@ -75,9 +75,216 @@ components:
           type: string
           enum: [new, in_progress, closed]
       required: [id, contactId, channel, status]
+    Organization:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          maxLength: 1000
+      required: [id, name]
+      example:
+        id: org_123
+        name: Acme Inc
+        description: Office space provider
+    OrganizationCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          maxLength: 1000
+      required: [name]
+      example:
+        name: Acme Inc
+        description: Office space provider
+    OrganizationUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          maxLength: 1000
+      minProperties: 1
+      example:
+        name: New Name
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+      required: [type, title, status]
+      example:
+        type: https://example.com/probs/conflict
+        title: Conflict
+        status: 409
+        detail: Resource already exists
 security:
   - bearerAuth: []
 paths:
+  /orgs:
+    post:
+      summary: Create organization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationCreate'
+            example:
+              name: Acme Inc
+              description: Office space provider
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+              example:
+                id: org_123
+                name: Acme Inc
+                description: Office space provider
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+  /orgs/{id}:
+    get:
+      summary: Get organization
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+              example:
+                id: org_123
+                name: Acme Inc
+                description: Office space provider
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+    patch:
+      summary: Update organization
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationUpdate'
+            example:
+              name: New Name
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+              example:
+                id: org_123
+                name: New Name
+                description: Office space provider
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '403':
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /orgs/{orgId}/offices:
     get:
       summary: List offices


### PR DESCRIPTION
Resolves #17
## Summary
- add organization schemas with examples
- document create, get, and update organization endpoints
- include RFC7807 error responses for organization operations

## Testing
- `ruby -ryaml -e 'YAML.load_file("openapi.yaml"); puts "YAML loaded"'`

------
https://chatgpt.com/codex/tasks/task_e_68c076b5480083279ecac890c2249e66