### PR TITLE
Clarify registration token flow and device binding

### DIFF
--- a/authn-authz.md
+++ b/authn-authz.md
@@ -1,8 +1,9 @@
 # AuthN/AuthZ Specification
 
 ## Registration & Login
-- **Registration**: `POST /auth/register` with email and password creates a new user account. Duplicate emails are rejected.
-- **Login**: `POST /auth/login` verifies credentials and returns an access and refresh JWT pair.
+- **Registration**: `POST /auth/register` with email, password, and optional `deviceId` creates a new user account. No tokens are issued. If verification is required the endpoint returns `202` and the user must confirm via `POST /auth/verify` before logging in.
+- **Verification**: `POST /auth/verify` with the emailed token activates the account.
+- **Login**: `POST /auth/login` verifies credentials and returns an access and refresh JWT pair bound to the supplied `deviceId`.
 
 ### Sequence: Login
 ```mermaid
@@ -29,6 +30,9 @@ sequenceDiagram
     A->>A: Validate & rotate token
     A-->>C: new access_token + refresh_token
 ```
+
+## Device Binding
+Refresh tokens are bound to the `deviceId` supplied during registration and login. Each client device should generate a stable identifier and include it with token refresh calls. Using a different `deviceId` invalidates the refresh token and requires a fresh login.
 
 ## Roles & Policies
 Users belong to one or more organizations and receive role‑based access:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -158,6 +158,9 @@ components:
             Must be at least 8 characters long and contain at least one letter and one digit.
         deviceId:
           type: string
+          description: |
+            Client generated identifier for the device. Refresh tokens are bound to this value.
+            See [Device Binding](authn-authz.md#device-binding).
         name:
           type: string
       required: [email, password]
@@ -218,8 +221,11 @@ paths:
     post:
       summary: Register user
       description: |
-        Registers a new user account.
-        See [Authentication & Authorization](authn-authz.md) for security details.
+        Registers a new user account. No access or refresh tokens are issued.
+        If verification is required the endpoint returns `202` and the user must call `POST /auth/verify`
+        before logging in to obtain tokens.
+        See [Authentication & Authorization](authn-authz.md#registration--login) for flow details and
+        [Device Binding](authn-authz.md#device-binding).
       security: []
       requestBody:
         required: true
@@ -234,7 +240,7 @@ paths:
               name: Alice
       responses:
         '201':
-          description: Created
+          description: Created - account ready for login
           content:
             application/json:
               schema:
@@ -244,7 +250,7 @@ paths:
                   id: usr_123
                   email: user@example.com
         '202':
-          description: Accepted - verification required
+          description: Accepted - verification required before login
         '400':
           description: Bad Request
           content:
@@ -273,8 +279,9 @@ paths:
     post:
       summary: Verify registration
       description: |
-        Verifies a user's email address using a token.
-        See [Authentication & Authorization](authn-authz.md) for security details.
+        Verifies a user's email address using a token. Successful verification enables login
+        to receive access and refresh tokens.
+        See [Authentication & Authorization](authn-authz.md#registration--login) for flow details.
       security: []
       requestBody:
         required: true


### PR DESCRIPTION
Resolves #23
## Summary
- Document that `/auth/register` returns no tokens and requires `/auth/verify` before login can issue JWTs
- Explain refresh token device binding semantics and add a dedicated section
- Link OpenAPI auth endpoints and `deviceId` schema back to authentication docs

## Testing
- `npx @redocly/cli@latest lint openapi.yaml` *(fails: 403 Forbidden fetching @redocly/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c19f26bc348327bf08a3ece2918630